### PR TITLE
fix(esm): esm import by outputting index.cjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "smile2emoji",
   "version": "3.9.0",
   "description": "Plugin to convert from text smile to emoticons. Emoji from punctuation",
-  "main": "./lib/index.js",
-  "module": "./lib/index.js",
+  "main": "./lib/index.cjs",
+  "module": "./lib/index.cjs",
   "types": "index.d.ts",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
@@ -25,7 +25,7 @@
     "cover": "nyc --check-coverage npm run test:only",
     "lint": "eslint src test",
     "build:types": "tsc --emitDeclarationOnly",
-    "build": "cross-env BABEL_ENV=production babel src --out-dir lib --extensions \".ts,.tsx\"",
+    "build": "cross-env BABEL_ENV=production babel src --out-file lib/index.cjs --extensions \".ts,.tsx\"",
     "prepare": "npm run clean && npm run lint && npm run test && npm run build"
   },
   "repository": {


### PR DESCRIPTION
This PR fixes #320 by outputting the build as `.cjs` instead of `.js`. This is needed since `package.json` now has `"type": "module"`.

I would actually prefer to just keep `index.js` as it is, and make TypeScript output esm code instead of commonjs. This is a breaking change however because it will no longer allow
```js
require('smile2emoji');
```

In my opinion this is not really a problem though as the module is mainly intended to be used on the client, which means people are using a bundler anyway. If you'd like to use the module on Node, then your code would need to be esm as well, but [it's something that you should consider doing anyway](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c).