### PR TITLE
Use conditional exports for esm and cjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,12 @@
   "name": "smile2emoji",
   "version": "3.9.1",
   "description": "Plugin to convert from text smile to emoticons. Emoji from punctuation",
-  "main": "./lib/index.cjs",
-  "module": "./lib/index.cjs",
+  "main": "./lib/index.js",
+  "module": "./lib/index.js",
+  "exports": {
+    "import": "./lib/index.js",
+    "require": "./lib/index.cjs"
+  },
   "types": "index.d.ts",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
@@ -25,7 +29,7 @@
     "cover": "nyc --check-coverage npm run test:only",
     "lint": "eslint src test",
     "build:types": "tsc --emitDeclarationOnly",
-    "build": "cross-env BABEL_ENV=production babel src --out-file lib/index.cjs --extensions \".ts,.tsx\"",
+    "build": "tsc && babel src --out-file lib/index.cjs --extensions \".ts,.tsx\"",
     "prepare": "npm run clean && npm run lint && npm run test && npm run build"
   },
   "repository": {


### PR DESCRIPTION
This PR changes the build to output both esm and commonjs in a non-breaking way.

Note that there's one problem with this approach though, which is the [dual package hazard](https://nodejs.org/api/packages.html#dual-package-hazard):

```js
import assert from 'node:assert';
import { createRequire } from 'node:module';
import { emojiMap } from 'smile2emoji';

const require = createRequire(import.meta.url);
const map = require('smile2emoji').emojiMap;

// This throws
assert.equal(emojiMap, map);
```
so this is *in theory* a breaking change too.

We could also rip the bandaid and no longer ship `.cjs`, which makes the module [esm only](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c-) and is of course a breaking change.